### PR TITLE
cache: remove log statements

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,7 +15,6 @@
 package safebrowsing
 
 import (
-	"log"
 	"sync"
 	"time"
 
@@ -58,8 +57,6 @@ type cache struct {
 	nttls map[hashPrefix]time.Time
 
 	now func() time.Time
-
-	log *log.Logger
 }
 
 // Update updates the cache according to the request that was made to the server
@@ -122,14 +119,12 @@ func (c *cache) Lookup(hash hashPrefix) (map[ThreatDescriptor]bool, cacheResult)
 			threats[td] = true
 		} else {
 			// The PTTL has expired, we should ask the server what's going on.
-			c.log.Printf("hash %x: expired PTTL", hash)
 			return nil, cacheMiss
 		}
 	}
 	if len(threats) > 0 {
 		// So long as there are valid threats, we report them. The positive TTL
 		// takes precedence over the negative TTL at the partial hash level.
-		c.log.Printf("hash %x: unsafe for %d threat(s)", hash, len(threats))
 		return threats, positiveCacheHit
 	}
 
@@ -160,7 +155,6 @@ func (c *cache) Purge() {
 				for i := minHashPrefixLength; i <= maxHashPrefixLength; i++ {
 					if nttl, ok := c.nttls[fullHash[:i]]; ok {
 						if nttl.After(pttl) {
-							c.log.Printf("hash %x: not purging since NTTL > PTTL", fullHash)
 							del = false
 							break
 						}

--- a/cache_test.go
+++ b/cache_test.go
@@ -15,8 +15,6 @@
 package safebrowsing
 
 import (
-	"io/ioutil"
-	"log"
 	"reflect"
 	"testing"
 	"time"
@@ -27,7 +25,6 @@ import (
 func TestCacheLookup(t *testing.T) {
 	now := time.Unix(1451436338, 951473000)
 	mockNow := func() time.Time { return now }
-	nilLogger := log.New(ioutil.Discard, "", 0)
 
 	type cacheLookup struct {
 		h   hashPrefix
@@ -54,7 +51,6 @@ func TestCacheLookup(t *testing.T) {
 				"BBBB": now.Add(-time.Minute),
 			},
 			now: mockNow,
-			log: nilLogger,
 		},
 		wantCache: &cache{
 			pttls: map[hashPrefix]map[ThreatDescriptor]time.Time{
@@ -66,7 +62,6 @@ func TestCacheLookup(t *testing.T) {
 				"AAAA": now.Add(DefaultUpdatePeriod),
 			},
 			now: mockNow,
-			log: nilLogger,
 		},
 		lookups: []cacheLookup{{
 			h:   "AAAABBBBBBBBBBBBBBBBBBBBBBBBBBBB",
@@ -98,7 +93,6 @@ func TestCacheLookup(t *testing.T) {
 				"BBBB": now.Add(-time.Minute),
 			},
 			now: mockNow,
-			log: nilLogger,
 		},
 		wantCache: &cache{
 			pttls: map[hashPrefix]map[ThreatDescriptor]time.Time{
@@ -111,7 +105,6 @@ func TestCacheLookup(t *testing.T) {
 				"AAAA": now.Add(DefaultUpdatePeriod * 2),
 			},
 			now: mockNow,
-			log: nilLogger,
 		},
 		lookups: []cacheLookup{{
 			h:   "AAAABBBBBBBBBBBBBBBBBBBBBBBBBBBB",
@@ -127,8 +120,8 @@ func TestCacheLookup(t *testing.T) {
 			r:   cacheMiss,
 		}},
 	}, {
-		gotCache:  &cache{now: mockNow, log: nilLogger},
-		wantCache: &cache{now: mockNow, log: nilLogger},
+		gotCache:  &cache{now: mockNow},
+		wantCache: &cache{now: mockNow},
 		lookups: []cacheLookup{{
 			h:   "AAAABBBBBBBBBBBBBBBBBBBBBBBBBBBB",
 			tds: nil,

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -315,7 +315,6 @@ func NewSafeBrowser(conf Config) (*SafeBrowser, error) {
 		w = ioutil.Discard
 	}
 	sb.log = log.New(w, "safebrowsing: ", log.Ldate|log.Ltime|log.Lshortfile)
-	sb.c.log = sb.log
 
 	// If database file is provided, use that to initialize.
 	if !sb.db.Init(&sb.config, sb.log) {


### PR DESCRIPTION
It's too noisy logging eviction actions since this is entirely
normal behavior of a cache.