### PR TITLE
Find a flaw in parsing URL

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -48,7 +48,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"log"
 
 	"golang.org/x/net/idna"
 )
@@ -281,7 +280,6 @@ func parseURL(urlStr string) (parsedURL *url.URL, err error) {
 	// If missing, we assume that it is an "http".
 	// 3. We strip off the fragment and the escaped query as they are not
 	// required for building patterns for Safe Browsing.
-	log.Printf("sssssssssssssss")
 	parsedURL = new(url.URL)
 	// Remove the URL fragment.
 	// Also, we decode and encode the URL.
@@ -327,9 +325,6 @@ func parseURL(urlStr string) (parsedURL *url.URL, err error) {
 		p += "/"
 	}
 	parsedURL.Path = p
-	log.Printf("parsedURL.Scheme: %v", parsedURL.Scheme)
-	log.Printf("parsedURL.Host: %v", parsedURL.Host)
-	log.Printf("parsedURL.Path: %v", parsedURL.Path)
 	return parsedURL, nil
 }
 

--- a/urls.go
+++ b/urls.go
@@ -48,13 +48,14 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"log"
 
 	"golang.org/x/net/idna"
 )
 
 var (
 	dotsRegexp          = regexp.MustCompile("[.]+")
-	portRegexp          = regexp.MustCompile(`:\d+$`)
+	portRegexp          = regexp.MustCompile(`:(\d+)(/|$)`)
 	possibleIPRegexp    = regexp.MustCompile(`^(?i)((?:0x[0-9a-f]+|[0-9\.])+)$`)
 	trailingSpaceRegexp = regexp.MustCompile(`^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) `)
 )
@@ -201,19 +202,6 @@ func normalizeEscape(s string) (string, error) {
 	return escape(u), nil
 }
 
-// parserest parase the content after the first symbol ':'.
-// If there is a port after ':',  ("", url) is returned. e.g. "www.abc.com:80/"
-// (url[:i], url[i+1:]) is returned in other stations.
-func parseRest(url string, i int) (scheme, path string) {
-	portReg := regexp.MustCompile(`^:(\d+)(/|$)`)
-	matched := portReg.MatchString(url[i:])
-	if matched {
-	    return "", url
-	}
-	    
-	return url[:i], url[i+1:]
-}
-
 // getScheme splits the url into (scheme, path) where scheme is the protocol.
 // If the scheme cannot be determined ("", url) is returned.
 func getScheme(url string) (scheme, path string) {
@@ -226,7 +214,12 @@ func getScheme(url string) (scheme, path string) {
 				return "", url
 			}
 		case c == ':':
-			return parseRest(url, i)
+			// If there is not a port after the first ':', (url[:i], url[i+1:])
+			// will be returned. e.g. "www.abc.com:80/".
+			firstIndex := portRegexp.FindStringIndex(url[i:])
+			if firstIndex == nil || firstIndex[0] != 0 {
+				return url[:i], url[i+1:]
+			}
 		default:
 			// Invalid character, so there is no valid scheme.
 			return "", url
@@ -288,7 +281,7 @@ func parseURL(urlStr string) (parsedURL *url.URL, err error) {
 	// If missing, we assume that it is an "http".
 	// 3. We strip off the fragment and the escaped query as they are not
 	// required for building patterns for Safe Browsing.
-
+	log.Printf("sssssssssssssss")
 	parsedURL = new(url.URL)
 	// Remove the URL fragment.
 	// Also, we decode and encode the URL.
@@ -334,6 +327,9 @@ func parseURL(urlStr string) (parsedURL *url.URL, err error) {
 		p += "/"
 	}
 	parsedURL.Path = p
+	log.Printf("parsedURL.Scheme: %v", parsedURL.Scheme)
+	log.Printf("parsedURL.Host: %v", parsedURL.Host)
+	log.Printf("parsedURL.Path: %v", parsedURL.Path)
 	return parsedURL, nil
 }
 

--- a/urls.go
+++ b/urls.go
@@ -201,6 +201,19 @@ func normalizeEscape(s string) (string, error) {
 	return escape(u), nil
 }
 
+// parserest parase the content after the first symbol ':'.
+// If there is a port after ':',  ("", url) is returned. e.g. "www.abc.com:80/"
+// (url[:i], url[i+1:]) is returned in other stations.
+func parseRest(url string, i int) (scheme, path string) {
+	portReg := regexp.MustCompile(`^:(\d+)(/|$)`)
+	matched := portReg.MatchString(url[i:])
+	if matched {
+	    return "", url
+	}
+	    
+	return url[:i], url[i+1:]
+}
+
 // getScheme splits the url into (scheme, path) where scheme is the protocol.
 // If the scheme cannot be determined ("", url) is returned.
 func getScheme(url string) (scheme, path string) {
@@ -213,7 +226,7 @@ func getScheme(url string) (scheme, path string) {
 				return "", url
 			}
 		case c == ':':
-			return url[:i], url[i+1:]
+			return parseRest(url, i)
 		default:
 			// Invalid character, so there is no valid scheme.
 			return "", url

--- a/urls_test.go
+++ b/urls_test.go
@@ -336,3 +336,44 @@ func TestCanonicalURL(t *testing.T) {
 		}
 	}
 }
+
+func TestParseURL(t *testing.T) {
+	vectors := []struct {
+		url    string
+		scheme string
+		host   string
+		path   srting
+		fail   bool
+	}{
+		{"www.google.com:8080/foo.html", "http", "www.google.com", "/foo.html", false},
+		{"www.google.com:80/", "http", "www.google.com", "/", false},
+		{"www.google.com:80", "http", "www.google.com", "/", false},
+		{":8080/foo.html", "http", "", "/foo.html", false},
+		
+		// The string after the first ":" is not a port.
+		{"http://www.google.com:8080/foo.html", "http", "www.google.com", "/foo.html", false},
+		{"http:www.google.com:8080/foo.html", "", "", "", true},
+		{"www.google.com:xxyy/foo.html:80", "", "", "", true},
+	}
+
+	for i, v := range vectors {
+		parsedURL, err := parseURL(v.url)
+		if err != nil != v.fail {
+			if err != nil {
+				t.Errorf("test %d url %v, unexpected error: %v", i, v.url, err)
+			} else {
+				t.Errorf("test %d, unexpected success", i)
+			}
+			continue
+		}
+		if parsedURL.Scheme != v.scheme {
+			t.Errorf("test %d, scheme of parseURL(%q) = %q, want %q", i, v.url, parsedURL.Scheme, v.scheme)
+		}
+		if parsedURL.Host != v.host {
+			t.Errorf("test %d, host of parseURL(%q) = %q, want %q", i, v.url, parsedURL.Host, v.host)
+		}
+		if parsedURL.Path != v.path {
+			t.Errorf("test %d, path of parseURL(%q) = %q, want %q", i, v.url, parsedURL.Path, v.path)
+		}
+	}
+}


### PR DESCRIPTION
Function getScheme in urls.go regards the string before the first symbol ':' as protocol and the path is after ':'. So sbserver  will report "invalid path" if the url's format is "domain:port/path". But I think it should be "http://domain/path" after being canonicalized. So I add a function to parse the string after ':'. It will return ("", url) if it is a port, so the protocol is empty and the rest is "domain:port/path". And (url[:i], url[i+1:]) will be returned in other stations.

For example, the result should be "http://www.gotaport.com/" after "http://www.gotaport.com:1234/" and "www.gotaport.com:1234/" being canonicalized. But sbserver's results are "http://www.gotaport.com/" and "invalid path".