### PR TITLE
Batch urls req

### DIFF
--- a/safebrowser.go
+++ b/safebrowser.go
@@ -370,9 +370,20 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 	// TODO: There are some optimizations to be made here:
 	//	1.) We could force a database update if it is in error.
 	//  However, we must ensure that we perform some form of rate-limiting.
-	//	2.) We should batch all of the partial hashes together such that we
-	//	call api.HashLookup only once.
-
+	// Construct the follow-up request being made to the server.
+	// In the request, we only ask for partial hashes for privacy reasons.
+	req := &pb.FindFullHashesRequest{
+		Client: &pb.ClientInfo{
+			ClientId:      sb.config.ID,
+			ClientVersion: sb.config.Version,
+		},
+		ThreatInfo: &pb.ThreatInfo{},
+	}
+	unsureFullHashes := make(map[hashPrefix]struct {
+		pattern  string
+		reqIndex int
+	})
+	var urlCount int64
 	for i, url := range urls {
 		hashes, err := generateHashes(url)
 		if err != nil {
@@ -381,18 +392,10 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 			return threats, err
 		}
 
-		// Construct the follow-up request being made to the server.
-		// In the request, we only ask for partial hashes for privacy reasons.
-		req := &pb.FindFullHashesRequest{
-			Client: &pb.ClientInfo{
-				ClientId:      sb.config.ID,
-				ClientVersion: sb.config.Version,
-			},
-			ThreatInfo: &pb.ThreatInfo{},
-		}
 		ttm := make(map[pb.ThreatType]bool)
 		ptm := make(map[pb.PlatformType]bool)
 		tetm := make(map[pb.ThreatEntryType]bool)
+		var notFound bool
 		for fullHash, pattern := range hashes {
 			// Lookup in database according to threat list.
 			partialHash, unsureThreats := sb.db.Lookup(fullHash)
@@ -428,8 +431,16 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 					ptm[pb.PlatformType(td.PlatformType)] = true
 					tetm[pb.ThreatEntryType(td.ThreatEntryType)] = true
 				}
+				unsureFullHashes[fullHash] = struct {
+					pattern  string
+					reqIndex int
+				}{
+					pattern,
+					i,
+				}
 				req.ThreatInfo.ThreatEntries = append(req.ThreatInfo.ThreatEntries,
 					&pb.ThreatEntry{Hash: []byte(partialHash)})
+				notFound = true
 			}
 		}
 		for tt := range ttm {
@@ -443,45 +454,46 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 		}
 
 		// All results are known, so just continue.
-		if len(req.ThreatInfo.ThreatEntries) == 0 {
+		if !notFound {
 			atomic.AddInt64(&sb.stats.QueriesByCache, 1)
 			continue
 		}
+		urlCount++
 
-		// Actually query the Safe Browsing API for exact full hash matches.
-		resp, err := sb.api.HashLookup(req)
-		if err != nil {
-			sb.log.Printf("HashLookup failure: %v", err)
-			atomic.AddInt64(&sb.stats.QueriesFail, int64(len(urls)-i))
-			return threats, err
+	}
+	// Actually query the Safe Browsing API for exact full hash matches.
+	resp, err := sb.api.HashLookup(req)
+	if err != nil {
+		sb.log.Printf("HashLookup failure: %v", err)
+		atomic.AddInt64(&sb.stats.QueriesFail, urlCount)
+		return threats, err
+	}
+
+	// Update the cache.
+	sb.c.Update(req, resp)
+
+	// Pull the information the client cares about out of the response.
+	for _, tm := range resp.GetMatches() {
+		fullHash := hashPrefix(tm.GetThreat().Hash)
+		if !fullHash.IsFull() {
+			continue
 		}
-
-		// Update the cache.
-		sb.c.Update(req, resp)
-
-		// Pull the information the client cares about out of the response.
-		for _, tm := range resp.GetMatches() {
-			fullHash := hashPrefix(tm.GetThreat().Hash)
-			if !fullHash.IsFull() {
+		if ith, ok := unsureFullHashes[fullHash]; ok {
+			td := ThreatDescriptor{
+				ThreatType:      ThreatType(tm.ThreatType),
+				PlatformType:    PlatformType(tm.PlatformType),
+				ThreatEntryType: ThreatEntryType(tm.ThreatEntryType),
+			}
+			if !sb.lists[td] {
 				continue
 			}
-			if pattern, ok := hashes[fullHash]; ok {
-				td := ThreatDescriptor{
-					ThreatType:      ThreatType(tm.ThreatType),
-					PlatformType:    PlatformType(tm.PlatformType),
-					ThreatEntryType: ThreatEntryType(tm.ThreatEntryType),
-				}
-				if !sb.lists[td] {
-					continue
-				}
-				threats[i] = append(threats[i], URLThreat{
-					Pattern:          pattern,
-					ThreatDescriptor: td,
-				})
-			}
+			threats[ith.reqIndex] = append(threats[ith.reqIndex], URLThreat{
+				Pattern:          ith.pattern,
+				ThreatDescriptor: td,
+			})
 		}
-		atomic.AddInt64(&sb.stats.QueriesByAPI, 1)
 	}
+	atomic.AddInt64(&sb.stats.QueriesByAPI, 1)
 	return threats, nil
 }
 

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -493,7 +493,7 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 			})
 		}
 	}
-	atomic.AddInt64(&sb.stats.QueriesByAPI, 1)
+	atomic.AddInt64(&sb.stats.QueriesByAPI, urlCount)
 	return threats, nil
 }
 

--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -152,22 +152,16 @@ func TestSafeBrowser(t *testing.T) {
 		ID:           "GoSafeBrowserSystemTest",
 		DBPath:       "/tmp/safebrowser.db",
 		UpdatePeriod: 10 * time.Second,
-		ThreatLists: []ThreatDescriptor{
-			{ThreatType_PotentiallyHarmfulApplication, PlatformType_Android, ThreatEntryType_URL},
-		},
+		ThreatLists:  DefaultThreatLists,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var c = pb.FetchThreatListUpdatesRequest_ListUpdateRequest{
-		ThreatType:      pb.ThreatType_POTENTIALLY_HARMFUL_APPLICATION,
-		PlatformType:    pb.PlatformType_ANDROID,
-		ThreatEntryType: pb.ThreatEntryType_URL,
-	}
 	urls := []string{
-		"http://testsafebrowsing.appspot.com/apiv4/" + c.PlatformType.String() + "/" +
-			c.ThreatType.String() + "/" + c.ThreatEntryType.String() + "/",
+		"http://testsafebrowsing.appspot.com/apiv4/" + pb.PlatformType_ANY_PLATFORM.String() + "/" + pb.ThreatType_SOCIAL_ENGINEERING.String() + "/" + pb.ThreatEntryType_URL.String() + "/",
+		"http://testsafebrowsing.appspot.com/apiv4/" + pb.PlatformType_ANY_PLATFORM.String() + "/" + pb.ThreatType_MALWARE.String() + "/" + pb.ThreatEntryType_URL.String() + "/",
+		"http://safebrowsing.appspot.com/apiv4/",
 	}
 	threats, e := sb.LookupURLs(urls)
 	if e != nil {
@@ -176,7 +170,12 @@ func TestSafeBrowser(t *testing.T) {
 	if len(threats[0]) == 0 {
 		t.Errorf("lookupURL failed")
 	}
-
+	if len(threats[1]) == 0 {
+		t.Errorf("lookupURL failed")
+	}
+	if len(threats[2]) != 0 {
+		t.Errorf("lookupURL failed")
+	}
 	if err := sb.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +185,7 @@ func TestSafeBrowser(t *testing.T) {
 			t.Errorf("Database length: got %d,, want >0", hs.Len())
 		}
 	}
-	if len(sb.c.pttls) != 1 {
+	if len(sb.c.pttls) != 2 {
 		t.Errorf("Cache length: got %d, want 1", len(sb.c.pttls))
 	}
 }


### PR DESCRIPTION
 batch all of the partial hashes together to call api.HashLookup only once.