### PR TITLE
`nil` panic fixes for misbehaving/buggy servers.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -80,7 +80,12 @@ func (c *cache) Update(req *pb.FindFullHashesRequest, resp *pb.FindFullHashesRes
 		if c.pttls[fullHash] == nil {
 			c.pttls[fullHash] = make(map[ThreatDescriptor]time.Time)
 		}
-		dur := time.Duration(tm.GetCacheDuration().Seconds) * time.Second
+		var dur time.Duration
+		if tmCacheDur := tm.GetCacheDuration(); tmCacheDur != nil {
+			dur = time.Duration(tm.GetCacheDuration().Seconds) * time.Second
+		} else {
+			dur = time.Second
+		}
 		td := ThreatDescriptor{
 			ThreatType:      ThreatType(tm.ThreatType),
 			PlatformType:    PlatformType(tm.PlatformType),

--- a/cache.go
+++ b/cache.go
@@ -84,7 +84,7 @@ func (c *cache) Update(req *pb.FindFullHashesRequest, resp *pb.FindFullHashesRes
 		if tmCacheDur := tm.GetCacheDuration(); tmCacheDur != nil {
 			dur = time.Duration(tm.GetCacheDuration().Seconds) * time.Second
 		} else {
-			dur = time.Second
+			dur = 0
 		}
 		td := ThreatDescriptor{
 			ThreatType:      ThreatType(tm.ThreatType),

--- a/database.go
+++ b/database.go
@@ -424,7 +424,9 @@ func (tfu threatsForUpdate) update(resp *pb.FetchThreatListUpdatesResponse) erro
 			return err
 		}
 
-		phs.SHA256 = m.GetChecksum().Sha256
+		if cs := m.GetChecksum(); cs != nil {
+			phs.SHA256 = cs.Sha256
+		}
 		if !bytes.Equal(phs.SHA256, phs.Hashes.SHA256()) {
 			return errors.New("safebrowsing: threat list SHA256 mismatch")
 		}


### PR DESCRIPTION
Hi folks :wave:

I've been working on a mock GSB server for integration testing. My goal was to implement the *bare minimum* of the protocol and so while developing I was frequently sending responses back to the `sblookup` utility I tested with that were not fully formed/populated.

In the process I noticed two nil panics from code assuming a well behaving server. I understand that its likely that the official GSB v4 server _won't_ return messages like this but in the interest of robustness I thought I would offer this PR to fix the two I uncovered. I haven't performed a comprehensive evaluation of whether there are other potential nil panics lurking - that might be a great follow up!

1) In `cache.go`: Prior to f78bcc8696c12113727adf8fc8f85747ded825fe if a (misbehaving/buggy) server returns a `FindFullHashesRequest` that includes one or more `ThreatMatch` objects that have a nil `CacheDuration` field the `cache.Update()` call will panic. f78bcc8696c12113727adf8fc8f85747ded825fe uses a default duration of `time.Second` when there is no `CacheDuration` set to avoid the nil panic. It might be more appropriate to produce an error, what are your thoughts?

2) In `database.go`: Prior to f78bcc8696c12113727adf8fc8f85747ded825fe if a (misbehaving/buggy) server returns a `FetchThreatListUpdatesResponse` that has one or more  `FetchThreatListUpdatesResponse_ListUpdateResponse` objects with a nil `Checksum` field the `threatsForUpdate.update()` call will panic. f78bcc8696c12113727adf8fc8f85747ded825fe guards the assignment of `phs.SHA256` based on whether the field is nil or not. If the field is nil we skip processing `phs.SHA256` and the `bytes.Equal` check will fail as expected without producing a panic.

Thanks!

