### PR TITLE
Add a  `-server` flag to `sblookup`.

### DIFF
--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -41,7 +41,7 @@ import (
 var (
 	apiKeyFlag    = flag.String("apikey", "", "specify your Safe Browsing API key")
 	databaseFlag  = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
-	serverUrlFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address")
+	serverURLFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address.")
 )
 
 const usage = `sblookup: command-line tool to lookup URLs with Safe Browsing.

--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -39,8 +39,9 @@ import (
 )
 
 var (
-	apiKeyFlag   = flag.String("apikey", "", "specify your Safe Browsing API key")
-	databaseFlag = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
+	apiKeyFlag    = flag.String("apikey", "", "specify your Safe Browsing API key")
+	databaseFlag  = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
+	serverUrlFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address")
 )
 
 const usage = `sblookup: command-line tool to lookup URLs with Safe Browsing.
@@ -77,9 +78,10 @@ func main() {
 		os.Exit(codeInvalid)
 	}
 	sb, err := safebrowsing.NewSafeBrowser(safebrowsing.Config{
-		APIKey: *apiKeyFlag,
-		DBPath: *databaseFlag,
-		Logger: os.Stderr,
+		APIKey:    *apiKeyFlag,
+		DBPath:    *databaseFlag,
+		Logger:    os.Stderr,
+		ServerURL: *serverUrlFlag,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Unable to initialize Safe Browsing client: ", err)

--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -81,7 +81,7 @@ func main() {
 		APIKey:    *apiKeyFlag,
 		DBPath:    *databaseFlag,
 		Logger:    os.Stderr,
-		ServerURL: *serverUrlFlag,
+		ServerURL: *serverURLFlag,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Unable to initialize Safe Browsing client: ", err)


### PR DESCRIPTION
This PR adds a new `-server` flag to the `sblookup` utility to allow specifying the API server to use for lookups. This is convenient for testing against a non-standard (e.g. mocked) GSB server. If it isn't provided the value defaults to `safebrowsing.DefaultServerURL`, preserving the `sblookup` behaviour prior to 2d4b3e238ee3c2115d11de3773c49c19007cd75a.