### PR TITLE
urls.go fix for Go 1.8

### DIFF
--- a/urls.go
+++ b/urls.go
@@ -426,13 +426,9 @@ func generateLookupHosts(urlStr string) ([]string, error) {
 		return nil, err
 	}
 	// handle IPv4 and IPv6 addresses.
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	ip := net.ParseIP(strings.Trim(u.Host, "[]"))
+	ip := net.ParseIP(strings.Trim(host, "[]"))
 	if ip != nil {
-		return []string{u.Host}, nil
+		return []string{host}, nil
 	}
 	hostComponents := strings.Split(host, ".")
 

--- a/urls_test.go
+++ b/urls_test.go
@@ -128,6 +128,7 @@ func TestCanonicalHost(t *testing.T) {
 			strings.ToLower("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]"), false},
 		{"http://[::192.9.5.5]/ipng", "[::192.9.5.5]", false},
 		{"http://0x12.0x43.0x44.0x01", "18.67.68.1", false},
+		{"http://192.168.0.1:80/index.html", "192.168.0.1", false},
 		{"/asdf", "", true},
 	}
 


### PR DESCRIPTION
Go 1.8 changed the behavior of url.Parse() to reject urls like
"this_that:other/thing" in accordance with RFC 3986. The change also rejects
an IPv6 address without a proper schema. Since this is something we want
to support, we instead use the host already parsed from canonicalHost()
as an input to net.ParseIP().