### PR TITLE
ErrDBNotReady allows the SafeBrowser users to get notified of the database readiness.

### DIFF
--- a/database.go
+++ b/database.go
@@ -108,7 +108,7 @@ type databaseFormat struct {
 // ErrDBNotReady is a public error type with a wait method for database.
 type ErrDBNotReady struct {
 	cause error
-	wg *sync.WaitGroup
+	wg    *sync.WaitGroup
 }
 
 func (e *ErrDBNotReady) Error() string {

--- a/database_test.go
+++ b/database_test.go
@@ -736,7 +736,7 @@ func TestDatabaseWaitGroup(t *testing.T) {
 	mockNow := func() time.Time { return now }
 
 	// Create a database.
-        db := &database{}
+	db := &database{}
 	config := &Config{
 		now: mockNow,
 	}


### PR DESCRIPTION
- New public error type, ErrDBNotReady, added with a wait group on the database readiness.
  db.Status() returns this error which is subsequently returned by NewSafeBrowser(), LookupURLs(). The user can choose to block wait on the database readiness by using err.Wait()

- Unit test, TestDatabaseWaitGroup, added to database_test for testing this new error type.