### PR TITLE
Alignment of stats struct for non-64-bit platforms.

### DIFF
--- a/safebrowser.go
+++ b/safebrowser.go
@@ -251,8 +251,8 @@ func (c Config) copy() Config {
 // local database and caching that would normally be needed to interact
 // with the API server.
 type SafeBrowser struct {
+	stats  Stats // Must be first for 64-bit alignment on non 64-bit systems.
 	config Config
-	stats  Stats
 	api    api
 	db     database
 	c      cache


### PR DESCRIPTION
closes #55

This is a documented issue for sync/atomic:
https://golang.org/pkg/sync/atomic/#pkg-note-BUG