### PR TITLE
Fix time.Time comparisons for upcoming Go1.9 monotonic times

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -642,7 +642,7 @@ func TestDatabasePersistence(t *testing.T) {
 	}{{
 		last: time.Time{},
 	}, {
-		last: time.Now(),
+		last: time.Now().Round(0), // Strip monotonic timestamp in Go1.9
 	}, {
 		last: time.Unix(123456, 789),
 		tfu: threatsForUpdate{


### PR DESCRIPTION
An upcoming change in Go1.9 changes the time.Time type to make a measurement
of both the wall clock and a monotonic clock. The existence of a monotonic
measurement makes it such that direct equality and use of reflect.DeepEqual
now fail. Fix those use cases by stripping out the monotonic measurement
so that equality continues to work.