### PR TITLE
Implement WaitUntilReady(ctx)

### DIFF
--- a/database.go
+++ b/database.go
@@ -17,6 +17,7 @@ package safebrowsing
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/gob"
 	"errors"
 	"log"
@@ -68,9 +69,10 @@ type database struct {
 	tfl threatsForLookup
 	ml  sync.RWMutex // Protects tfl, err, and last
 
-	err             error     // Last error encountered
-	last            time.Time // Last time the threat list were synced
-	updateAPIErrors uint      // Number of times we attempted to contact the api and failed
+	err             error         // Last error encountered
+	errCh           chan struct{} // Used for waiting until not in an error state.
+	last            time.Time     // Last time the threat list were synced
+	updateAPIErrors uint          // Number of times we attempted to contact the api and failed
 
 	log *log.Logger
 }
@@ -100,11 +102,14 @@ type databaseFormat struct {
 // Init initializes the database from the specified file in config.DBPath.
 // It reports true if the database was successfully loaded.
 func (db *database) Init(config *Config, logger *log.Logger) bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.setError(errors.New("not intialized"))
 	db.config = config
 	db.log = logger
 	if db.config.DBPath == "" {
 		db.log.Printf("no database file specified")
-		db.setError(errStale)
+		db.setError(errors.New("no database loaded"))
 		return false
 	}
 	dbf, err := loadDatabase(db.config.DBPath)
@@ -118,7 +123,9 @@ func (db *database) Init(config *Config, logger *log.Logger) bool {
 	// superset of the specified configuration.
 	if db.config.now().Sub(dbf.Time) > (db.config.UpdatePeriod + jitter) {
 		db.log.Printf("database loaded is stale")
-		db.setError(errStale)
+		db.ml.Lock()
+		defer db.ml.Unlock()
+		db.setStale()
 		return false
 	}
 	tfuNew := make(threatsForUpdate)
@@ -126,8 +133,8 @@ func (db *database) Init(config *Config, logger *log.Logger) bool {
 		if row, ok := dbf.Table[td]; ok {
 			tfuNew[td] = row
 		} else {
-			db.log.Printf("database configuration mismatch")
-			db.setError(errStale)
+			db.log.Printf("database configuration mismatch, missing %v", td)
+			db.setError(errors.New("database configuration mismatch"))
 			return false
 		}
 	}
@@ -146,7 +153,8 @@ func (db *database) Status() error {
 		return db.err
 	}
 	if db.config.now().Sub(db.last) > (db.config.UpdatePeriod + jitter) {
-		return errStale
+		db.setStale()
+		return db.err
 	}
 	return nil
 }
@@ -167,6 +175,17 @@ func (db *database) SinceLastUpdate() time.Duration {
 	defer db.ml.RUnlock()
 
 	return db.config.now().Sub(db.last)
+}
+
+// WaitUntilReady blocks until the database is not in an error state,
+// or the provided Context is cancelled.
+func (db *database) WaitUntilReady(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-db.errCh:
+		return nil
+	}
 }
 
 // Update synchronizes the local threat lists with those maintained by the
@@ -287,8 +306,36 @@ func (db *database) setError(err error) {
 	db.tfu = nil
 
 	db.ml.Lock()
+	if db.err == nil {
+		db.errCh = make(chan struct{})
+	}
 	db.tfl, db.err, db.last = nil, err, time.Time{}
 	db.ml.Unlock()
+}
+
+// setStale sets the error state to a stale message, without clearing
+// the database state.
+//
+// This assumes that the db.ml lock is already held.
+func (db *database) setStale() {
+	if db.err == nil {
+		db.errCh = make(chan struct{})
+	}
+	db.err = errStale
+}
+
+// clearError clears the db error state, and unblocks any callers of
+// WaitUntilReady.
+//
+// This assumes that the db.mu lock is already held.
+func (db *database) clearError() {
+	db.ml.Lock()
+	defer db.ml.Unlock()
+
+	if db.err != nil {
+		close(db.errCh)
+	}
+	db.err = nil
 }
 
 // generateThreatsForUpdate regenerates the threatsForUpdate hashes from
@@ -329,10 +376,11 @@ func (db *database) generateThreatsForLookups(last time.Time) {
 
 	db.ml.Lock()
 	wasBad := db.err != nil
-	db.tfl, db.err, db.last = tfl, nil, last
+	db.tfl, db.last = tfl, last
 	db.ml.Unlock()
 
 	if wasBad {
+		db.clearError()
 		db.log.Printf("database is now healthy")
 	}
 }

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -72,6 +72,7 @@
 package safebrowsing
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -356,6 +357,12 @@ func (sb *SafeBrowser) Status() (Stats, error) {
 		DatabaseUpdateLag: sb.db.UpdateLag(),
 	}
 	return stats, sb.db.Status()
+}
+
+// WaitUntilReady blocks until the database is not in an error state,
+// or until the provided Context is cancelled.
+func (sb *SafeBrowser) WaitUntilReady(ctx context.Context) error {
+	return sb.db.WaitUntilReady(ctx)
 }
 
 // LookupURLs looks up the provided URLs. It returns a list of threats, one for

--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -161,10 +161,10 @@ func TestSafeBrowser(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	if err := sb.WaitUntilReady(ctx); err != nil {
 		t.Fatal(err)
 	}
+	cancel()
 
 	var c = pb.FetchThreatListUpdatesRequest_ListUpdateRequest{
 		ThreatType:      pb.ThreatType_POTENTIALLY_HARMFUL_APPLICATION,
@@ -186,6 +186,11 @@ func TestSafeBrowser(t *testing.T) {
 	if err := sb.Close(); err != nil {
 		t.Fatal(err)
 	}
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	if err := sb.WaitUntilReady(ctx); err != errClosed {
+		t.Errorf("sb.WaitUntilReady() = %v on closed SafeBrowser, want %v", err, errClosed)
+	}
+	cancel()
 
 	for _, hs := range sb.db.tfl {
 		if hs.Len() == 0 {

--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -15,6 +15,7 @@
 package safebrowsing
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
@@ -157,6 +158,11 @@ func TestSafeBrowser(t *testing.T) {
 		},
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := sb.WaitUntilReady(ctx); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Allows callers to block until the database is in a non-error state, or
until the provided context is cancelled.

Also cleaned up some of the errors set in Init that marked the DB as
stale when it was actually just completely broken.

This is the second part of issue #44