### PR TITLE
Fix travis for brittle test in vendored code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ go:
 
 script:
   - test -z "$(gofmt -s -l $(find . -name '*.go' -type f -print) | tee /dev/stderr)"
-  - go test -v ./...
-  - go test -race -v ./...
+  - go test -v $(go list ./... | grep -v vendor)
+  - go test -race -v $(go list ./... | grep -v vendor)


### PR DESCRIPTION
The jsonpb_test.go depends upon precise number formatting that changed between Go 1.7 and 1.8