### PR TITLE
Provides LookupURLsContext to allow granular cancellation.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -120,7 +120,7 @@ func TestNetAPI(t *testing.T) {
 		t.Errorf("mismatching HashLookup responses:\ngot  %+v\nwant %+v", gotResp, wantResp)
 	}
 
-	// Test cancelled Context returns an error.
+	// Test canceled Context returns an error.
 	wantReq = &pb.FindFullHashesRequest{ThreatInfo: &pb.ThreatInfo{
 		ThreatEntries:    []*pb.ThreatEntry{{Hash: []byte("aaaa")}, {Hash: []byte("bbbbb")}, {Hash: []byte("cccccc")}},
 		ThreatTypes:      []pb.ThreatType{1, 2, 3},
@@ -137,7 +137,7 @@ func TestNetAPI(t *testing.T) {
 	cancel()
 	_, err = api.HashLookup(ctx, wantReq.(*pb.FindFullHashesRequest))
 	if err == nil {
-		t.Errorf("unexpected HashLookup success, wanted http request cancelled")
+		t.Errorf("unexpected HashLookup success, wanted HTTP request canceled")
 	}
 
 	// Test for detection of incorrect protobufs.

--- a/api_test.go
+++ b/api_test.go
@@ -15,6 +15,7 @@
 package safebrowsing
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -27,16 +28,16 @@ import (
 )
 
 type mockAPI struct {
-	listUpdate func(*pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error)
-	hashLookup func(*pb.FindFullHashesRequest) (*pb.FindFullHashesResponse, error)
+	listUpdate func(context.Context, *pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error)
+	hashLookup func(context.Context, *pb.FindFullHashesRequest) (*pb.FindFullHashesResponse, error)
 }
 
-func (m *mockAPI) ListUpdate(req *pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error) {
-	return m.listUpdate(req)
+func (m *mockAPI) ListUpdate(ctx context.Context, req *pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error) {
+	return m.listUpdate(ctx, req)
 }
 
-func (m *mockAPI) HashLookup(req *pb.FindFullHashesRequest) (*pb.FindFullHashesResponse, error) {
-	return m.hashLookup(req)
+func (m *mockAPI) HashLookup(ctx context.Context, req *pb.FindFullHashesRequest) (*pb.FindFullHashesResponse, error) {
+	return m.hashLookup(ctx, req)
 }
 
 func TestNetAPI(t *testing.T) {
@@ -60,7 +61,7 @@ func TestNetAPI(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, err := newNetAPI(ts.URL, "fizzbuzz", 0)
+	api, err := newNetAPI(ts.URL, "fizzbuzz")
 	if err != nil {
 		t.Errorf("unexpected newNetAPI error: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestNetAPI(t *testing.T) {
 		}}},
 	}}
 	gotReq = &pb.FetchThreatListUpdatesRequest{}
-	resp1, err := api.ListUpdate(wantReq.(*pb.FetchThreatListUpdatesRequest))
+	resp1, err := api.ListUpdate(context.Background(), wantReq.(*pb.FetchThreatListUpdatesRequest))
 	gotResp = resp1
 	if err != nil {
 		t.Errorf("unexpected ListUpdate error: %v", err)
@@ -107,7 +108,7 @@ func TestNetAPI(t *testing.T) {
 		{ThreatType: 2, PlatformType: 3, ThreatEntryType: 4, Threat: &pb.ThreatEntry{Hash: []byte("ijkl")}},
 	}}
 	gotReq = &pb.FindFullHashesRequest{}
-	resp2, err := api.HashLookup(wantReq.(*pb.FindFullHashesRequest))
+	resp2, err := api.HashLookup(context.Background(), wantReq.(*pb.FindFullHashesRequest))
 	gotResp = resp2
 	if err != nil {
 		t.Errorf("unexpected HashLookup error: %v", err)
@@ -119,6 +120,26 @@ func TestNetAPI(t *testing.T) {
 		t.Errorf("mismatching HashLookup responses:\ngot  %+v\nwant %+v", gotResp, wantResp)
 	}
 
+	// Test cancelled Context returns an error.
+	wantReq = &pb.FindFullHashesRequest{ThreatInfo: &pb.ThreatInfo{
+		ThreatEntries:    []*pb.ThreatEntry{{Hash: []byte("aaaa")}, {Hash: []byte("bbbbb")}, {Hash: []byte("cccccc")}},
+		ThreatTypes:      []pb.ThreatType{1, 2, 3},
+		PlatformTypes:    []pb.PlatformType{4, 5, 6},
+		ThreatEntryTypes: []pb.ThreatEntryType{7, 8, 9},
+	}}
+	wantResp = &pb.FindFullHashesResponse{Matches: []*pb.ThreatMatch{
+		{ThreatType: 0, PlatformType: 1, ThreatEntryType: 2, Threat: &pb.ThreatEntry{Hash: []byte("abcd")}},
+		{ThreatType: 1, PlatformType: 2, ThreatEntryType: 3, Threat: &pb.ThreatEntry{Hash: []byte("efgh")}},
+		{ThreatType: 2, PlatformType: 3, ThreatEntryType: 4, Threat: &pb.ThreatEntry{Hash: []byte("ijkl")}},
+	}}
+	gotReq = &pb.FindFullHashesRequest{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = api.HashLookup(ctx, wantReq.(*pb.FindFullHashesRequest))
+	if err == nil {
+		t.Errorf("unexpected HashLookup success, wanted http request cancelled")
+	}
+
 	// Test for detection of incorrect protobufs.
 	wantReq = &pb.FindFullHashesRequest{ThreatInfo: &pb.ThreatInfo{
 		ThreatEntryTypes: []pb.ThreatEntryType{7, 8, 9},
@@ -127,7 +148,7 @@ func TestNetAPI(t *testing.T) {
 		{ThreatType: 1, PlatformType: 2, ThreatEntryType: 3, ResponseType: 1},
 	}}
 	gotReq = &pb.FindFullHashesRequest{}
-	_, err = api.HashLookup(wantReq.(*pb.FindFullHashesRequest))
+	_, err = api.HashLookup(context.Background(), wantReq.(*pb.FindFullHashesRequest))
 	if err == nil {
 		t.Errorf("unexpected HashLookup success")
 	}

--- a/cmd/sbserver/main.go
+++ b/cmd/sbserver/main.go
@@ -358,7 +358,7 @@ func serveLookups(resp http.ResponseWriter, req *http.Request, sb *safebrowsing.
 	}
 
 	// Lookup the URLs.
-	utss, err := sb.LookupURLs(urls)
+	utss, err := sb.LookupURLsContext(req.Context(), urls)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		return
@@ -463,7 +463,7 @@ func serveRedirector(resp http.ResponseWriter, req *http.Request, sb *safebrowsi
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	threats, err := sb.LookupURLs([]string{rawURL})
+	threats, err := sb.LookupURLsContext(req.Context(), []string{rawURL})
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		return

--- a/database.go
+++ b/database.go
@@ -17,6 +17,7 @@ package safebrowsing
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/gob"
 	"errors"
 	"log"
@@ -185,7 +186,7 @@ func (db *database) Ready() <-chan struct{} {
 // Update synchronizes the local threat lists with those maintained by the
 // global Safe Browsing API servers. If the update is successful, Status should
 // report a nil error.
-func (db *database) Update(api api) (time.Duration, bool) {
+func (db *database) Update(ctx context.Context, api api) (time.Duration, bool) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
@@ -218,7 +219,7 @@ func (db *database) Update(api api) (time.Duration, bool) {
 
 	// Query the API for the threat list and update the database.
 	last := db.config.now()
-	resp, err := api.ListUpdate(req)
+	resp, err := api.ListUpdate(ctx, req)
 	if err != nil {
 		db.log.Printf("ListUpdate failure (%d): %v", db.updateAPIErrors+1, err)
 		db.setError(err)

--- a/database_test.go
+++ b/database_test.go
@@ -353,7 +353,7 @@ func TestDatabaseUpdate(t *testing.T) {
 	var resp pb.FetchThreatListUpdatesResponse
 	var errResponse error
 	mockAPI := &mockAPI{
-		listUpdate: func(*pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error) {
+		listUpdate: func(context.Context, *pb.FetchThreatListUpdatesRequest) (*pb.FetchThreatListUpdatesResponse, error) {
 			return &resp, errResponse
 		},
 	}
@@ -377,7 +377,7 @@ func TestDatabaseUpdate(t *testing.T) {
 		},
 		MinimumWaitDuration: &google_protobuf.Duration{Seconds: 1200},
 	}
-	delay, updated := db.Update(mockAPI)
+	delay, updated := db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 0, unexpected update success")
 	}
@@ -402,7 +402,7 @@ func TestDatabaseUpdate(t *testing.T) {
 		},
 		MinimumWaitDuration: &google_protobuf.Duration{Seconds: 2000},
 	}
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err != nil || !updated {
 		t.Fatalf("update 1, unexpected update error: %v", db.err)
 	}
@@ -450,7 +450,7 @@ func TestDatabaseUpdate(t *testing.T) {
 				"d1", "a3b93fac424834c2447e2dbe5db3ec8553519777523907ea310e207f556a7637"),
 		},
 	}
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err != nil || !updated {
 		t.Fatalf("update 2, unexpected update error: %v", db.err)
 	}
@@ -480,7 +480,7 @@ func TestDatabaseUpdate(t *testing.T) {
 				"d2", "b742965b7a759ba0254685bfc6edae3b1ba54d0168fb86f526d6c79c3d44c753"),
 		},
 	}
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err != nil || !updated {
 		t.Fatalf("update 3, unexpected update error: %v", db.err)
 	}
@@ -518,7 +518,7 @@ func TestDatabaseUpdate(t *testing.T) {
 				"a3", "bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0"),
 		},
 	}
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 4, unexpected update success")
 	}
@@ -539,7 +539,7 @@ func TestDatabaseUpdate(t *testing.T) {
 				"a4", "5d6506974928a003d2a0ccbd7a40b5341ad10578fd3f54527087c5ecbbd17a12"),
 		},
 	}
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 5, unexpected update success")
 	}
@@ -554,7 +554,7 @@ func TestDatabaseUpdate(t *testing.T) {
 
 	// Update 6: api is broken for some unknown reason. Checks the backoff
 	errResponse = errors.New("Something broke")
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 6, unexpected update success")
 	}
@@ -565,7 +565,7 @@ func TestDatabaseUpdate(t *testing.T) {
 	}
 
 	// Update 7: api is still broken, check backoff is larger
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 7, unexpected update success")
 	}
@@ -576,7 +576,7 @@ func TestDatabaseUpdate(t *testing.T) {
 	}
 
 	// Update 8: api is still broken, check that backoff is larger than before
-	delay, updated = db.Update(mockAPI)
+	delay, updated = db.Update(context.Background(), mockAPI)
 	if db.err == nil || updated {
 		t.Fatalf("update 8, unexpected update success")
 	}

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -298,7 +298,7 @@ func NewSafeBrowser(conf Config) (*SafeBrowser, error) {
 	// Create the SafeBrowsing object.
 	if conf.api == nil {
 		var err error
-		conf.api, err = newNetAPI(conf.ServerURL, conf.APIKey, conf.RequestTimeout)
+		conf.api, err = newNetAPI(conf.ServerURL, conf.APIKey)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +331,9 @@ func NewSafeBrowser(conf Config) (*SafeBrowser, error) {
 	delay := time.Duration(0)
 	// If database file is provided, use that to initialize.
 	if !sb.db.Init(&sb.config, sb.log) {
-		delay, _ = sb.db.Update(sb.api)
+		ctx, cancel := context.WithTimeout(context.Background(), sb.config.RequestTimeout)
+		delay, _ = sb.db.Update(ctx, sb.api)
+		cancel()
 	} else {
 		if age := sb.db.SinceLastUpdate(); age < sb.config.UpdatePeriod {
 			delay = sb.config.UpdatePeriod - age
@@ -391,6 +393,18 @@ func (sb *SafeBrowser) WaitUntilReady(ctx context.Context) error {
 // If an error occurs, the caller should treat the threats list returned as a
 // best-effort response to the query. The results may be stale or be partial.
 func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err error) {
+	threats, err = sb.LookupURLsContext(context.Background(), urls)
+	return threats, err
+}
+
+// LookupURLsContext looks up the provided URLs, with the ability to cancel the
+// request via a provided context. It is safe to call this method concurrently.
+//
+// See SafeBrowser.LookupURLs for details on the returned results.
+func (sb *SafeBrowser) LookupURLsContext(ctx context.Context, urls []string) (threats [][]URLThreat, err error) {
+	ctx, cancel := context.WithTimeout(ctx, sb.config.RequestTimeout)
+	defer cancel()
+
 	threats = make([][]URLThreat, len(urls))
 
 	if atomic.LoadUint32(&sb.closed) != 0 {
@@ -482,7 +496,7 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 
 	// Actually query the Safe Browsing API for exact full hash matches.
 	if len(req.ThreatInfo.ThreatEntries) != 0 {
-		resp, err := sb.api.HashLookup(req)
+		resp, err := sb.api.HashLookup(ctx, req)
 		if err != nil {
 			sb.log.Printf("HashLookup failure: %v", err)
 			atomic.AddInt64(&sb.stats.QueriesFail, 1)
@@ -533,10 +547,12 @@ func (sb *SafeBrowser) updater(delay time.Duration) {
 		select {
 		case <-time.After(delay):
 			var ok bool
-			if delay, ok = sb.db.Update(sb.api); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), sb.config.RequestTimeout)
+			if delay, ok = sb.db.Update(ctx, sb.api); ok {
 				sb.log.Printf("background threat list updated")
 				sb.c.Purge()
 			}
+			cancel()
 
 		case <-sb.done:
 			return

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -397,10 +397,11 @@ func (sb *SafeBrowser) LookupURLs(urls []string) (threats [][]URLThreat, err err
 	return threats, err
 }
 
-// LookupURLsContext looks up the provided URLs, with the ability to cancel the
-// request via a provided context. It is safe to call this method concurrently.
+// LookupURLsContext looks up the provided URLs. The request will be canceled
+// if the provided Context is canceled, or if Config.RequestTimeout has
+// elapsed. It is safe to call this method concurrently.
 //
-// See SafeBrowser.LookupURLs for details on the returned results.
+// See LookupURLs for details on the returned results.
 func (sb *SafeBrowser) LookupURLsContext(ctx context.Context, urls []string) (threats [][]URLThreat, err error) {
 	ctx, cancel := context.WithTimeout(ctx, sb.config.RequestTimeout)
 	defer cancel()

--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -34,7 +34,7 @@ func TestNetworkAPIUpdate(t *testing.T) {
 		t.Skip()
 	}
 
-	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag, time.Minute)
+	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestNetworkAPIUpdate(t *testing.T) {
 		}}
 	req := &pb.FetchThreatListUpdatesRequest{ListUpdateRequests: lists}
 
-	dat, err := nm.ListUpdate(req)
+	dat, err := nm.ListUpdate(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestNetworkAPIUpdate(t *testing.T) {
 						ThreatEntries:    threats,
 					},
 				}
-				fullHashResp, err := nm.HashLookup(fullHashReq)
+				fullHashResp, err := nm.HashLookup(context.Background(), fullHashReq)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -113,7 +113,7 @@ func TestNetworkAPILookup(t *testing.T) {
 		t.Skip()
 	}
 
-	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag, time.Minute)
+	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestNetworkAPILookup(t *testing.T) {
 			ThreatEntries:    []*pb.ThreatEntry{{Hash: []byte(hash[:minHashPrefixLength])}},
 		},
 	}
-	resp, err := nm.HashLookup(req)
+	resp, err := nm.HashLookup(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Lookup failed: %v", err)
 	}


### PR DESCRIPTION
This change plumbs contexts through all API calls, and
replaces the http.Client timeout mechanism introduced in #59.

The sbserver example implementation propogates the http.Request
context to provide cancellation if the client disconnects.

Fixes #73