### PR TITLE
Added proxy support

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -61,7 +61,7 @@ func TestNetAPI(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	api, err := newNetAPI(ts.URL, "fizzbuzz")
+	api, err := newNetAPI(ts.URL, "fizzbuzz", "")
 	if err != nil {
 		t.Errorf("unexpected newNetAPI error: %v", err)
 	}

--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -42,6 +42,7 @@ var (
 	apiKeyFlag    = flag.String("apikey", "", "specify your Safe Browsing API key")
 	databaseFlag  = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
 	serverURLFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address.")
+	proxyFlag     = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
 )
 
 const usage = `sblookup: command-line tool to lookup URLs with Safe Browsing.
@@ -82,6 +83,7 @@ func main() {
 		DBPath:    *databaseFlag,
 		Logger:    os.Stderr,
 		ServerURL: *serverURLFlag,
+		ProxyURL:  *proxyFlag,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Unable to initialize Safe Browsing client: ", err)

--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -42,7 +42,7 @@ var (
 	apiKeyFlag    = flag.String("apikey", "", "specify your Safe Browsing API key")
 	databaseFlag  = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
 	serverURLFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address.")
-	proxyFlag     = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
+	proxyFlag     = flag.String("proxy", "", "proxy to use to connect to the HTTP server")
 )
 
 const usage = `sblookup: command-line tool to lookup URLs with Safe Browsing.

--- a/cmd/sbserver/main.go
+++ b/cmd/sbserver/main.go
@@ -222,7 +222,7 @@ const (
 var (
 	apiKeyFlag   = flag.String("apikey", "", "specify your Safe Browsing API key")
 	srvAddrFlag  = flag.String("srvaddr", "localhost:8080", "TCP network address the HTTP server should use")
-	proxyFlag    = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
+	proxyFlag    = flag.String("proxy", "", "proxy to use to connect to the HTTP server")
 	databaseFlag = flag.String("db", "", "path to the Safe Browsing database.")
 )
 

--- a/cmd/sbserver/main.go
+++ b/cmd/sbserver/main.go
@@ -222,6 +222,7 @@ const (
 var (
 	apiKeyFlag   = flag.String("apikey", "", "specify your Safe Browsing API key")
 	srvAddrFlag  = flag.String("srvaddr", "localhost:8080", "TCP network address the HTTP server should use")
+	proxyFlag    = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
 	databaseFlag = flag.String("db", "", "path to the Safe Browsing database.")
 )
 
@@ -504,9 +505,10 @@ func main() {
 		os.Exit(1)
 	}
 	conf := safebrowsing.Config{
-		APIKey: *apiKeyFlag,
-		DBPath: *databaseFlag,
-		Logger: os.Stderr,
+		APIKey:   *apiKeyFlag,
+		ProxyURL: *proxyFlag,
+		DBPath:   *databaseFlag,
+		Logger:   os.Stderr,
 	}
 	sb, err := safebrowsing.NewSafeBrowser(conf)
 	if err != nil {

--- a/safebrowser.go
+++ b/safebrowser.go
@@ -185,6 +185,10 @@ type Config struct {
 	// If empty, it defaults to DefaultServerURL.
 	ServerURL string
 
+	// ProxyURL is the URL of the proxy to use for all requests.
+	// If empty, the underlying library uses $HTTP_PROXY environment variable.
+	ProxyURL string
+
 	// APIKey is the key used to authenticate with the Safe Browsing API
 	// service. This field is required.
 	APIKey string
@@ -298,7 +302,7 @@ func NewSafeBrowser(conf Config) (*SafeBrowser, error) {
 	// Create the SafeBrowsing object.
 	if conf.api == nil {
 		var err error
-		conf.api, err = newNetAPI(conf.ServerURL, conf.APIKey)
+		conf.api, err = newNetAPI(conf.ServerURL, conf.APIKey, conf.ProxyURL)
 		if err != nil {
 			return nil, err
 		}

--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -34,7 +34,7 @@ func TestNetworkAPIUpdate(t *testing.T) {
 		t.Skip()
 	}
 
-	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag)
+	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag, "")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestNetworkAPILookup(t *testing.T) {
 		t.Skip()
 	}
 
-	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag)
+	nm, err := newNetAPI(DefaultServerURL, *apiKeyFlag, "")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
A proxy can now be used by using the -proxy parameter in both sblookup and sbserver. This overrides the default use of the environment variable HTTP_PROXY (or http_proxy). Please refer to https://golang.org/pkg/net/http/#RoundTripper for more info