### PR TITLE
Fixes issue querying multiple overlapping urls

### DIFF
--- a/safebrowser_system_test.go
+++ b/safebrowser_system_test.go
@@ -171,15 +171,15 @@ func TestSafeBrowser(t *testing.T) {
 		PlatformType:    pb.PlatformType_ANDROID,
 		ThreatEntryType: pb.ThreatEntryType_URL,
 	}
-	urls := []string{
-		"http://testsafebrowsing.appspot.com/apiv4/" + c.PlatformType.String() + "/" +
-			c.ThreatType.String() + "/" + c.ThreatEntryType.String() + "/",
-	}
+	url := "http://testsafebrowsing.appspot.com/apiv4/" + c.PlatformType.String() + "/" +
+		c.ThreatType.String() + "/" + c.ThreatEntryType.String() + "/"
+
+	urls := []string{url, url + "?q=test"}
 	threats, e := sb.LookupURLs(urls)
 	if e != nil {
 		t.Fatal(e)
 	}
-	if len(threats[0]) == 0 {
+	if len(threats[0]) == 0 || len(threats[1]) == 0 {
 		t.Errorf("lookupURL failed")
 	}
 


### PR DESCRIPTION
If more than one url had a suffix/prefix expression that was the same
(example foo.com/a and foo.com/b both would also test foo.com), only the
last one would be recorded. If it matched a blacklist, only that last
one would show the match.

Note: This did not affect any cached items. So if the offending full
hash had already been cached, all urls covered by that expression would
be correctly shown as matches.

Fixes #87