### PR TITLE
Travis: use newer Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: go
 
 go:
-  - 1.7
-  - 1.8
+  - "1.8"
+  - "1.9"
+  - "1.10"
+  - "1.11"
 
 script:
-  - test -z "$(gofmt -s -l $(find . -name '*.go' -type f -print) | tee /dev/stderr)"
+  - test -z "$(gofmt -s -l $(find . -name '*.go' -type f -not -path "./vendor/*" -not -name "*.pb.go" -print) | tee /dev/stderr)"
   - go test -v $(go list ./... | grep -v vendor)
   - go test -race -v $(go list ./... | grep -v vendor)


### PR DESCRIPTION
- Remove Go 1.7 and add 1.9 - 1.11.
- Explicitly use strings to avoid version numbers being interpreted as decimal numbers in YAML.
- Exempt generated and vendored files from the gofmt check (we would get different results depending on the Go version)